### PR TITLE
Fix deep get_group_replays

### DIFF
--- a/ballchasing/api.py
+++ b/ballchasing/api.py
@@ -311,7 +311,7 @@ class Api:
         """
         child_groups = self.get_groups(group=group_id)
         for child in child_groups:
-            for replay in self.get_group_replays(child["id"]):
+            for replay in self.get_group_replays(child["id"], deep):
                 yield replay
         for replay in self.get_replays(group_id=group_id, deep=deep):
             yield replay


### PR DESCRIPTION
I just recently started using your library and found a bug (or at the very least, unexpected behavior). When using `get_group_replays`, the `deep` argument currently does not get passed down the recursive calls for child groups. This PR fixes that behavior (all child replays retrieved will be using the parent's deep argument).